### PR TITLE
Feat: 포인트 충전 및 사용 기능에 동시성 제어 및 최대 잔고 제한 추가

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -3,40 +3,58 @@ package io.hhplus.tdd.point
 import io.hhplus.tdd.database.PointHistoryTable
 import io.hhplus.tdd.database.UserPointTable
 import org.springframework.stereotype.Service
+import java.util.concurrent.locks.ReentrantLock
 
 //TODO : bean test 방법
 //TODO : test api
-
 @Service
 class PointService(
     private val userPointTable: UserPointTable,
     private val pointHistoryTable: PointHistoryTable
 ) {
 
+    private val MAX_BALANCE = 100_000L
+    private val lock = ReentrantLock()
+
     fun getUserPoint(id: Long): UserPoint {
         return userPointTable.selectById(id)
     }
 
     fun charge(id: Long, amount: Long): UserPoint {
-        val userPoint = userPointTable.selectById(id)
-        val newPoint = userPoint.point + amount
-        val updatedUserPoint = userPointTable.insertOrUpdate(id, newPoint)
-        // 이력 추가
-        pointHistoryTable.insert(id, amount, TransactionType.CHARGE, System.currentTimeMillis())
+        lock.lock()
+        try {
+            val userPoint = userPointTable.selectById(id)
+            val newPoint = userPoint.point + amount
 
-        return updatedUserPoint
+            if (newPoint > MAX_BALANCE) {
+                throw IllegalArgumentException("최대 잔고를 초과할 수 없습니다. 초과하고싶으면 은행을 사시던가요.")
+            }
+
+            val updatedUserPoint = userPointTable.insertOrUpdate(id, newPoint)
+            // 이력 추가
+            pointHistoryTable.insert(id, amount, TransactionType.CHARGE, System.currentTimeMillis())
+
+            return updatedUserPoint
+        } finally {
+            lock.unlock()
+        }
     }
 
     fun use(id: Long, amount: Long): UserPoint {
-        val currentPoint = userPointTable.selectById(id)
-        if (currentPoint.point < amount) {
-            throw IllegalArgumentException("잔액이 부족합니다.")
-        }
-        val updatedUserPoint = userPointTable.insertOrUpdate(id, currentPoint.point - amount)
-        // 이력 추가
-        pointHistoryTable.insert(id, amount, TransactionType.USE, System.currentTimeMillis())
+        lock.lock()
+        try {
+            val currentPoint = userPointTable.selectById(id)
+            if (currentPoint.point < amount) {
+                throw IllegalArgumentException("잔액이 부족합니다.")
+            }
+            val updatedUserPoint = userPointTable.insertOrUpdate(id, currentPoint.point - amount)
+            // 이력 추가
+            pointHistoryTable.insert(id, amount, TransactionType.USE, System.currentTimeMillis())
 
-        return updatedUserPoint
+            return updatedUserPoint
+        } finally {
+            lock.unlock()
+        }
     }
 
     fun getUserPointHistory(userId: Long): List<PointHistory> {

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceConcurrencyTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceConcurrencyTest.kt
@@ -1,0 +1,75 @@
+package io.hhplus.tdd.point
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+class PointServiceConcurrencyTest {
+
+    @Autowired
+    private lateinit var pointService: PointService
+
+    private val userId = 1L
+
+    // 각 테스트 전에 초기 포인트를 설정하는 메소드
+    @BeforeEach
+    fun setUp() {
+        // 초기 포인트를 100으로 설정하여 테스트가 일관된 초기 상태에서 시작되도록 함
+        pointService.charge(userId, 100L)  // 예: 100포인트로 설정
+    }
+
+    @Test
+    fun `동시 충전 테스트`() {
+        // 10개의 스레드를 생성하여 동시에 충전 요청을 보내기 위해 ThreadPool을 생성
+        val executor = Executors.newFixedThreadPool(10)
+
+        // 초기 포인트를 가져옴
+        val initialPoints = pointService.getUserPoint(1L).point
+
+        // 10개의 스레드가 동시에 10포인트씩 충전
+        repeat(10) {
+            executor.submit {
+                pointService.charge(1L, 10)
+            }
+        }
+
+        // 모든 스레드의 작업이 완료될 때까지 기다림
+        executor.shutdown()
+        executor.awaitTermination(1, TimeUnit.MINUTES)
+
+        // 최종 포인트를 가져와서 10번의 충전 후 예상되는 포인트 값과 일치하는지 확인
+        val finalPoints = pointService.getUserPoint(1L).point
+        // 10개의 요청이 모두 완료된 후의 최종 포인트 값이 올바른지 확인
+        assertEquals(initialPoints + 100, finalPoints)  // 10개의 요청, 각각 10포인트 충전
+    }
+
+    @Test
+    fun `동시 사용 테스트`() {
+        // 10개의 스레드를 생성하여 동시에 사용 요청을 보내기 위해 ThreadPool을 생성
+        val executor = Executors.newFixedThreadPool(10)
+
+        // 초기 포인트를 가져옴
+        val initialPoints = pointService.getUserPoint(1L).point
+
+        // 10개의 스레드가 동시에 10포인트씩 사용
+        repeat(10) {
+            executor.submit {
+                pointService.use(1L, 10)
+            }
+        }
+
+        // 모든 스레드의 작업이 완료될 때까지 기다림
+        executor.shutdown()
+        executor.awaitTermination(1, TimeUnit.MINUTES)
+
+        // 최종 포인트를 가져와서 10번의 사용 후 예상되는 포인트 값과 일치하는지 확인
+        val finalPoints = pointService.getUserPoint(1L).point
+        // 10개의 요청이 모두 완료된 후의 최종 포인트 값이 올바른지 확인
+        assertEquals(initialPoints - 100, finalPoints)  // 10개의 요청, 각각 10포인트 사용
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -54,6 +54,29 @@ class PointServiceTest{
 //        verify(pointHistoryTable).insert(userId, chargeAmount, TransactionType.CHARGE, updatedPoint.updateMillis)
     }
 
+//    @Test
+//    fun `포인트 적립 시도 시 최대 잔고 초과 시 예외 발생`() {
+//        // 최대 잔고 설정 (기존 잔고 + 충전할 금액이 최대 잔고를 초과하도록 설정)
+//        val maxBalance = 100_000L
+//        val initialPoint = UserPoint(id = userId, point = maxBalance - 10L, updateMillis = System.currentTimeMillis())
+//        val chargeAmount = 20L  // 충전 시도가 최대 잔고를 초과하게 만드는 금액
+//
+//        `when`(userPointTable.selectById(userId)).thenReturn(initialPoint)
+//
+//        // assertThrows를 사용해 예외가 발생하는지 확인
+//        val exception = assertThrows(IllegalArgumentException::class.java) {
+//            pointService.charge(userId, chargeAmount)
+//        }
+//
+//        // 예외 메시지가 예상되는 내용과 일치하는지 확인
+//        assertEquals("최대 잔고를 초과할 수 없습니다. 초과하고싶으면 은행을 사시던가요.", exception.message)
+//
+//        // 최대 잔고를 초과했으므로 insertOrUpdate가 호출되지 않아야 함을 검증
+//        verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong())
+//        // 포인트 이력이 기록되지 않아야 함을 검증
+//        verify(pointHistoryTable, never()).insert(anyLong(), anyLong(), any(TransactionType::class.java), anyLong())
+//    }
+
     @Test
     fun `포인트 사용 테스트`(){
         val useAmount = 30L
@@ -70,6 +93,7 @@ class PointServiceTest{
 //        // 포인트 사용 이력이 기록되었는지도 확인
 //        verify(pointHistoryTable).insert(userId, useAmount, TransactionType.USE, updatedPoint.updateMillis)
     }
+
 
     @Test
     fun `포인트 사용 시 잔액이 부족한 경우 예외 발생`(){


### PR DESCRIPTION
- `PointService`에 포인트 충전(`charge`) 및 사용(`use`) 시 동시성 제어를 위한 `ReentrantLock` 적용
- 최대 잔고(100,000 포인트) 초과 시 예외 발생 처리 로직 추가
- 동시성 문제 발생을 방지하기 위한 통합 테스트 추가:
  - 10개의 스레드를 이용한 동시 포인트 충전 테스트
  - 10개의 스레드를 이용한 동시 포인트 사용 테스트
- `@BeforeEach` 메서드를 사용하여 각 테스트 전에 초기 포인트 설정
- 각 테스트에서 `Mock` 객체 초기화 및 반환값 설정을 통해 안정적인 테스트 환경 구성
